### PR TITLE
Avoid sending unsupported query commands

### DIFF
--- a/src/OppoTelnet/Enums.cs
+++ b/src/OppoTelnet/Enums.cs
@@ -107,7 +107,11 @@ public enum PlaybackStatus
     HomeMenu,
     MediaCenter,
     ScreenSaver,
-    DiscMenu
+    DiscMenu,
+    
+    // Pre 20X models
+    Loading,
+    Close
 }
 
 public enum DiscType

--- a/src/OppoTelnet/OppoClient.cs
+++ b/src/OppoTelnet/OppoClient.cs
@@ -1324,6 +1324,11 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
                         "@OK MEDIA CENTER" => PlaybackStatus.MediaCenter,
                         "@OK SCREEN SAVER" => PlaybackStatus.ScreenSaver,
                         "@OK DISC MENU" => PlaybackStatus.DiscMenu,
+                        
+                        // Pre 20X models
+                        "@OK LOADING" => PlaybackStatus.Loading,
+                        "OK CLOSE" => PlaybackStatus.Close,
+                        "@OK UNKNOW" => PlaybackStatus.Unknown,
                         _ => LogError(result.Response, PlaybackStatus.Unknown)
                     }
                 }

--- a/src/UnfoldedCircle.Server/WebSocket/UnfoldedCircleWebSocketHandler.MediaUpdate.cs
+++ b/src/UnfoldedCircle.Server/WebSocket/UnfoldedCircleWebSocketHandler.MediaUpdate.cs
@@ -106,10 +106,13 @@ internal partial class UnfoldedCircleWebSocketHandler
                                 if (elapsedResponse.Value)
                                 {
                                     remainingResponse = await oppoClientHolder.Client.QueryTrackOrTitleRemainingTimeAsync(cancellationTokenWrapper.ApplicationStopping);
-                                    
-                                    trackResponse = await oppoClientHolder.Client.QueryTrackNameAsync(cancellationTokenWrapper.ApplicationStopping);
-                                    album = (await oppoClientHolder.Client.QueryTrackAlbumAsync(cancellationTokenWrapper.ApplicationStopping)).Result;
-                                    performer = (await oppoClientHolder.Client.QueryTrackPerformerAsync(cancellationTokenWrapper.ApplicationStopping)).Result;   
+
+                                    if (oppoClientHolder.ClientKey.Model is OppoModel.UDP20X)
+                                    {
+                                        trackResponse = await oppoClientHolder.Client.QueryTrackNameAsync(cancellationTokenWrapper.ApplicationStopping);
+                                        album = (await oppoClientHolder.Client.QueryTrackAlbumAsync(cancellationTokenWrapper.ApplicationStopping)).Result;
+                                        performer = (await oppoClientHolder.Client.QueryTrackPerformerAsync(cancellationTokenWrapper.ApplicationStopping)).Result;                                        
+                                    }
                                 }
                             }
                             


### PR DESCRIPTION
Sending them to devices that don't support them causes a long pause in the application as the device doesn't send any response at all.