### PR TITLE
Fix 10X model responses

### DIFF
--- a/src/OppoTelnet/Enums.cs
+++ b/src/OppoTelnet/Enums.cs
@@ -110,7 +110,9 @@ public enum PlaybackStatus
     DiscMenu,
     
     // Pre 20X models
+    NoDisc,
     Loading,
+    Open,
     Close
 }
 
@@ -125,7 +127,10 @@ public enum DiscType
     DataDisc,
     UltraHDBluRay,
     NoDisc,
-    UnknownDisc
+    UnknownDisc,
+    
+    // Pre 20X models
+    HDCD
     // ReSharper restore InconsistentNaming
 }
 

--- a/src/OppoTelnet/Oppo10XCommand.cs
+++ b/src/OppoTelnet/Oppo10XCommand.cs
@@ -295,35 +295,6 @@ internal static class Oppo10XCommand
     public static readonly byte[] PictureAdjustment = "REMOTE SEH"u8.ToArray();
     
     /// <summary>
-    /// Display the HDR selection menu
-    /// </summary>
-    // ReSharper disable InconsistentNaming
-    public static readonly byte[] HDR = "REMOTE HDR"u8.ToArray();
-    // ReSharper restore InconsistentNaming
-    
-    /// <summary>
-    /// Show on-screen detailed information
-    /// </summary>
-    public static readonly byte[] InfoHold = "REMOTE INH"u8.ToArray();
-    
-    /// <summary>
-    /// Set resolution to Auto (default)
-    /// </summary>
-    public static readonly byte[] ResolutionHold = "REMOTE RLH"u8.ToArray();
-    
-    /// <summary>
-    /// Display the A/V Sync adjustment menu
-    /// </summary>
-    // ReSharper disable InconsistentNaming
-    public static readonly byte[] AVSync = "REMOTE AVS"u8.ToArray();
-    // ReSharper restore InconsistentNaming
-    
-    /// <summary>
-    /// Gapless Play. This functions the same as selecting Gapless Play in the Option Menu.
-    /// </summary>
-    public static readonly byte[] GaplessPlay = "REMOTE GPA"u8.ToArray();
-    
-    /// <summary>
     /// No operation.
     /// </summary>
     public static readonly byte[] Noop = "REMOTE NOP"u8.ToArray();
@@ -407,27 +378,6 @@ internal static class Oppo10XQueryCommand
     /// Query Repeat Mode
     /// </summary>
     public static readonly byte[] QueryRepeatMode = "REMOTE QRP"u8.ToArray();
-    
-    /// <summary>
-    /// Query CDDB number
-    /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public static readonly byte[] QueryCDDBNumber = "REMOTE QCD"u8.ToArray();
-    
-    /// <summary>
-    /// Query track name
-    /// </summary>
-    public static readonly byte[] QueryTrackName = "REMOTE QTN"u8.ToArray();
-    
-    /// <summary>
-    /// Query track album
-    /// </summary>
-    public static readonly byte[] QueryTrackAlbum = "REMOTE QTA"u8.ToArray();
-    
-    /// <summary>
-    /// Query track performer
-    /// </summary>
-    public static readonly byte[] QueryTrackPerformer = "REMOTE QTP"u8.ToArray();
 }
 
 internal static class Oppo10XAdvancedCommand
@@ -447,20 +397,13 @@ internal static class Oppo10XAdvancedCommand
     /// </summary>
     public static readonly byte[] SetVerboseModeDetailedStatus = "REMOTE SVM 3"u8.ToArray();
     
-    public static readonly byte[] SetHDMIResolutionAuto = "REMOTE SHD AUTO"u8.ToArray();
+    public static readonly byte[] SetHDMIResolutionSDI = "REMOTE SHD SDI"u8.ToArray();
+    public static readonly byte[] SetHDMIResolutionSDP = "REMOTE SHD SDP"u8.ToArray();
+    public static readonly byte[] SetHDMIResolution720P = "REMOTE SHD 720P"u8.ToArray();
+    public static readonly byte[] SetHDMIResolution1080I = "REMOTE SHD 1080I"u8.ToArray();
+    public static readonly byte[] SetHDMIResolution1080P = "REMOTE SHD 1080P"u8.ToArray();
     public static readonly byte[] SetHDMIResolutionSource = "REMOTE SHD SRC"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution1080PAuto = "REMOTE SHD 1080P_AUTO"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution1080P24 = "REMOTE SHD 1080P24"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution1080P50 = "REMOTE SHD 1080P50"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution1080P60 = "REMOTE SHD 1080P60"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution1080I50 = "REMOTE SHD 1080I50"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution1080I60 = "REMOTE SHD 1080I60"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution720P50 = "REMOTE SHD 720P50"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution720P60 = "REMOTE SHD 720P60"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution576P = "REMOTE SHD 576P"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution576I = "REMOTE SHD 576I"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution480P = "REMOTE SHD 480P"u8.ToArray();
-    public static readonly byte[] SetHDMIResolution480I = "REMOTE SHD 480I"u8.ToArray();
+    public static readonly byte[] SetHDMIResolutionAuto = "REMOTE SHD AUTO"u8.ToArray();
     
     /// <summary>
     /// Repeat chapter

--- a/src/OppoTelnet/OppoClient.cs
+++ b/src/OppoTelnet/OppoClient.cs
@@ -1087,13 +1087,15 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
     
     public async ValueTask<bool> InfoHoldAsync(CancellationToken cancellationToken = default)
     {
+        if (_model is not OppoModel.UDP20X)
+            return false;
+        
         if (!await _semaphore.WaitAsync(_timeout, cancellationToken))
             return false;
         
         try
         {
-            var command = _model == OppoModel.UDP20X ? Oppo20XCommand.InfoHold : Oppo10XCommand.InfoHold;
-            var result = await SendCommand(command, cancellationToken);
+            var result = await SendCommand(Oppo20XCommand.InfoHold, cancellationToken);
             return result.Success;
         }
         finally
@@ -1104,13 +1106,15 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
     
     public async ValueTask<bool> ResolutionHoldAsync(CancellationToken cancellationToken = default)
     {
+        if (_model is not OppoModel.UDP20X)
+            return false;
+        
         if (!await _semaphore.WaitAsync(_timeout, cancellationToken))
             return false;
         
         try
         {
-            var command = _model == OppoModel.UDP20X ? Oppo20XCommand.ResolutionHold : Oppo10XCommand.ResolutionHold;
-            var result = await SendCommand(command, cancellationToken);
+            var result = await SendCommand(Oppo20XCommand.ResolutionHold, cancellationToken);
             return result.Success;
         }
         finally
@@ -1121,13 +1125,15 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
     
     public async ValueTask<bool> AVSyncAsync(CancellationToken cancellationToken = default)
     {
+        if (_model is not OppoModel.UDP20X)
+            return false;
+        
         if (!await _semaphore.WaitAsync(_timeout, cancellationToken))
             return false;
         
         try
         {
-            var command = _model == OppoModel.UDP20X ? Oppo20XCommand.AVSync : Oppo10XCommand.AVSync;
-            var result = await SendCommand(command, cancellationToken);
+            var result = await SendCommand(Oppo20XCommand.AVSync, cancellationToken);
             return result.Success;
         }
         finally
@@ -1138,13 +1144,15 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
     
     public async ValueTask<bool> GaplessPlayAsync(CancellationToken cancellationToken = default)
     {
+        if (_model is not OppoModel.UDP20X)
+            return false;
+        
         if (!await _semaphore.WaitAsync(_timeout, cancellationToken))
             return false;
         
         try
         {
-            var command = _model == OppoModel.UDP20X ? Oppo20XCommand.GaplessPlay : Oppo10XCommand.GaplessPlay;
-            var result = await SendCommand(command, cancellationToken);
+            var result = await SendCommand(Oppo20XCommand.GaplessPlay, cancellationToken);
             return result.Success;
         }
         finally
@@ -1326,7 +1334,9 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
                         "@OK DISC MENU" => PlaybackStatus.DiscMenu,
                         
                         // Pre 20X models
+                        "@OK NO DISC" => PlaybackStatus.NoDisc,
                         "@OK LOADING" => PlaybackStatus.Loading,
+                        "@OK OPEN" => PlaybackStatus.Open,
                         "OK CLOSE" => PlaybackStatus.Close,
                         "@OK UNKNOW" => PlaybackStatus.Unknown,
                         _ => LogError(result.Response, PlaybackStatus.Unknown)
@@ -1391,6 +1401,9 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
                         "@OK UHBD" => DiscType.UltraHDBluRay,
                         "@OK NO-DISC" => DiscType.NoDisc,
                         "@OK UNKNOWN-DISC" => DiscType.UnknownDisc,
+                        
+                        // Pre 20X models
+                        "@OK HDCD" => DiscType.HDCD,
                         _ => LogError(result.Response, DiscType.UnknownDisc)
                     }
                 }
@@ -1440,13 +1453,15 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
     
     public async ValueTask<OppoResult<string>> QueryCDDBNumberAsync(CancellationToken cancellationToken = default)
     {
+        if (_model is not OppoModel.UDP20X)
+            return false;
+        
         if (!await _semaphore.WaitAsync(_timeout, cancellationToken))
             return false;
         
         try
         {
-            var command = _model == OppoModel.UDP20X ? Oppo20XQueryCommand.QueryCDDBNumber : Oppo10XQueryCommand.QueryCDDBNumber;
-            var result = await SendCommand(command, cancellationToken);
+            var result = await SendCommand(Oppo20XQueryCommand.QueryCDDBNumber, cancellationToken);
         
             return result.Success switch
             {
@@ -1466,13 +1481,15 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
 
     public async ValueTask<OppoResult<string>> QueryTrackNameAsync(CancellationToken cancellationToken = default)
     {
+        if (_model is not OppoModel.UDP20X)
+            return false;
+        
         if (!await _semaphore.WaitAsync(_timeout, cancellationToken))
             return false;
         
         try
         {
-            var command = _model == OppoModel.UDP20X ? Oppo20XQueryCommand.QueryTrackName : Oppo10XQueryCommand.QueryTrackName;
-            var result = await SendCommand(command, cancellationToken);
+            var result = await SendCommand(Oppo20XQueryCommand.QueryTrackName, cancellationToken);
         
             return result.Success switch
             {
@@ -1492,13 +1509,15 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
 
     public async ValueTask<OppoResult<string>> QueryTrackAlbumAsync(CancellationToken cancellationToken = default)
     {
+        if (_model is not OppoModel.UDP20X)
+            return false;
+        
         if (!await _semaphore.WaitAsync(_timeout, cancellationToken))
             return false;
         
         try
         {
-            var command = _model == OppoModel.UDP20X ? Oppo20XQueryCommand.QueryTrackAlbum : Oppo10XQueryCommand.QueryTrackAlbum;
-            var result = await SendCommand(command, cancellationToken);
+            var result = await SendCommand(Oppo20XQueryCommand.QueryTrackAlbum, cancellationToken);
         
             return result.Success switch
             {
@@ -1518,13 +1537,15 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
 
     public async ValueTask<OppoResult<string>> QueryTrackPerformerAsync(CancellationToken cancellationToken = default)
     {
+        if (_model is not OppoModel.UDP20X)
+            return false;
+        
         if (!await _semaphore.WaitAsync(_timeout, cancellationToken))
             return false;
         
         try
         {
-            var command = _model == OppoModel.UDP20X ? Oppo20XQueryCommand.QueryTrackPerformer : Oppo10XQueryCommand.QueryTrackPerformer;
-            var result = await SendCommand(command, cancellationToken);
+            var result = await SendCommand(Oppo20XQueryCommand.QueryTrackPerformer, cancellationToken);
         
             return result.Success switch
             {
@@ -1668,9 +1689,8 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
     {
         if (isFirstWrite)
         {
-            // Models prior to UDP-20X can have different prefixes than @OK and @ER (e.g. @QPW, @VUP, @VDN)
-            // Check if second char is V or Q, remove the first five chars so we just write @OK or @ER
-            if (_model != OppoModel.UDP20X && span.Length > 5 && span[1] is 0x56 or 0x51)
+            // Models prior to UDP-20X doesn't send back @OK or @ER, rather it's @(COMMAND_CODE) followed by OK|ER and then the response
+            if (_model != OppoModel.UDP20X && (!span.StartsWith("@OK "u8) || !span.StartsWith("@ER "u8)))
             {
                 _stringBuilder.Append('@');
                 int charsDecoded = Encoding.ASCII.GetChars(span[5..], charBuffer);


### PR DESCRIPTION
- 10X models command responses always begin with ``@(COMMAND_CODE) OK|ER ...`
- Remove commands that are not supported by 10X models
- Map enums that are unique to 10X models