### PR TITLE
Reduce log level for when mDNS client isn't allowed to send.

### DIFF
--- a/src/Mdns/MulticastClient.cs
+++ b/src/Mdns/MulticastClient.cs
@@ -137,7 +137,7 @@ internal class MulticastClient : IDisposable
             }
             catch (Exception e)
             {
-                _logger?.LogError(e, "Sender {Key} failure.", sender.Key);
+                _logger?.LogInformation(e, "Sender {Key} failure.", sender.Key);
                 // eat it.
             }
         }


### PR DESCRIPTION
Avoid spamming logs with expected errors - failing to send a mDSN message is often not serious and can be because of firewall rules.