### PR TITLE
Better handling of media events

### DIFF
--- a/src/UnfoldedCircle.Server/WebSocket/UnfoldedCircleWebSocketHandler.Event.cs
+++ b/src/UnfoldedCircle.Server/WebSocket/UnfoldedCircleWebSocketHandler.Event.cs
@@ -28,7 +28,7 @@ internal partial class UnfoldedCircleWebSocketHandler
                     wsId,
                     cancellationTokenWrapper.ApplicationStopping);
 
-                if (deviceState == DeviceState.Connected)
+                if (deviceState is DeviceState.Connected)
                     _ = HandleEventUpdates(socket, wsId, oppoClientHolder!, cancellationTokenWrapper);
                 
                 return;
@@ -88,8 +88,8 @@ internal partial class UnfoldedCircleWebSocketHandler
                         wsId,
                         cancellationTokenWrapper.ApplicationStopping);
                     
-                    if (oppoClientHolder is not null && await oppoClientHolder.Client.IsConnectedAsync())
-                        _ = HandleEventUpdates(socket, wsId, oppoClientHolder, cancellationTokenWrapper);
+                    if (deviceState is DeviceState.Connected)
+                        _ = HandleEventUpdates(socket, wsId, oppoClientHolder!, cancellationTokenWrapper);
                     return;
                 }
             default:

--- a/src/UnfoldedCircle.Server/WebSocket/UnfoldedCircleWebSocketHandler.OppoClient.cs
+++ b/src/UnfoldedCircle.Server/WebSocket/UnfoldedCircleWebSocketHandler.OppoClient.cs
@@ -159,8 +159,12 @@ internal partial class UnfoldedCircleWebSocketHandler
         
         try
         {
-            if (await oppoClientHolder.Client.IsConnectedAsync())
-                return DeviceState.Connected;
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(9));
+            while (!cancellationTokenSource.IsCancellationRequested)
+            {
+                if (await oppoClientHolder.Client.IsConnectedAsync())
+                    return DeviceState.Connected;
+            }
 
             return DeviceState.Disconnected;
         }


### PR DESCRIPTION
Integration would sometimes not resume sending media events after the remote wakes up from sleep.
Try to fix it by:
- Making sure that device reports that it's on before continuing
- Only report Off when turning off
- Use State.On as fallback instead of Unknown (device is on after all)