### PR TITLE
Drop the support for using chapter length on movies

### DIFF
--- a/src/Oppo/IOppoClient.cs
+++ b/src/Oppo/IOppoClient.cs
@@ -337,11 +337,13 @@ public interface IOppoClient : IDisposable
     /// <summary>
     /// Query Chapter elapsed time
     /// </summary>
+    // ReSharper disable once UnusedMember.Global
     ValueTask<OppoResult<uint>> QueryChapterElapsedTimeAsync(CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Query Chapter remaining time
     /// </summary>
+    // ReSharper disable once UnusedMember.Global
     ValueTask<OppoResult<uint>> QueryChapterRemainingTimeAsync(CancellationToken cancellationToken = default);
     
     /// <summary>

--- a/src/Oppo/OppoClientKey.cs
+++ b/src/Oppo/OppoClientKey.cs
@@ -1,4 +1,4 @@
 namespace Oppo;
 
-public record struct OppoClientKey(string HostName, in OppoModel Model, in bool UseMediaEvents, in bool UseStreamingEvents, in bool UseChapterLengthForMovies,
+public record struct OppoClientKey(string HostName, in OppoModel Model, in bool UseMediaEvents, in bool UseStreamingEvents,
     string EntityId, string? DeviceId, string? MacAddress);

--- a/src/UnfoldedCircle.OppoBluRay/Configuration/OppoConfigurationItem.cs
+++ b/src/UnfoldedCircle.OppoBluRay/Configuration/OppoConfigurationItem.cs
@@ -7,6 +7,5 @@ public record OppoConfigurationItem : UnfoldedCircle.Server.Configuration.Unfold
     public required OppoModel Model { get; init; }
     public required bool UseMediaEvents { get; init; }
     public required bool UseStreamingEvents { get; init; }
-    public required bool UseChapterLengthForMovies { get; init; }
     public required string? MacAddress { get; init; }
 }

--- a/src/UnfoldedCircle.OppoBluRay/OppoEntity/OppoConstants.cs
+++ b/src/UnfoldedCircle.OppoBluRay/OppoEntity/OppoConstants.cs
@@ -8,9 +8,6 @@ internal static class OppoConstants
     internal const string EntityName = "entity_name";
     internal const string UseMediaEventsKey = "use_media_events";
     internal const string UseStreamingEventsKey = "use_streaming_events";
-    internal const string ChapterLengthValue = "chapter_length";
-    internal const string MovieLengthValue = "movie_length";
-    internal const string ChapterOrMovieLengthKey = "chapter_or_movie_length";
     internal const string MaxMessageHandlingWaitTimeInSecondsKey = "max_message_handling_wait_time_in_seconds";
 
     internal const string IpAddressRegex = @"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|(([0-9a-fA-F]{1,4}:)" +

--- a/src/UnfoldedCircle.OppoBluRay/WebSocket/OppoWebSocketHandler.EntityEvent.cs
+++ b/src/UnfoldedCircle.OppoBluRay/WebSocket/OppoWebSocketHandler.EntityEvent.cs
@@ -389,16 +389,11 @@ public partial class OppoWebSocketHandler
     {
         if (snapshot.IsMovie)
         {
-            snapshot.ElapsedResponse = oppoClientHolder.ClientKey.UseChapterLengthForMovies
-                ? await oppoClientHolder.Client.QueryChapterElapsedTimeAsync(cancellationToken)
-                : await oppoClientHolder.Client.QueryTotalElapsedTimeAsync(cancellationToken);
+            snapshot.ElapsedResponse = await oppoClientHolder.Client.QueryTotalElapsedTimeAsync(cancellationToken);
 
             if (snapshot.ElapsedResponse is { Success: true })
             {
-                snapshot.RemainingResponse = oppoClientHolder.ClientKey.UseChapterLengthForMovies
-                    ? await oppoClientHolder.Client.QueryChapterRemainingTimeAsync(cancellationToken)
-                    : await oppoClientHolder.Client.QueryTotalRemainingTimeAsync(cancellationToken);
-
+                snapshot.RemainingResponse = await oppoClientHolder.Client.QueryTotalRemainingTimeAsync(cancellationToken);
                 snapshot.MediaDuration = GetMediaDuration(snapshot.ElapsedResponse, snapshot.RemainingResponse);
             }
 
@@ -798,9 +793,17 @@ public partial class OppoWebSocketHandler
         OppoPlaybackProgressStreamingEvent playbackProgressEvent,
         CancellationToken cancellationToken)
     {
-        // Rebuild if title/chapter changed – this invalidates track metadata and progress domain
-        if (context.Snapshot.LastProgressTitle != playbackProgressEvent.Title
-            || context.Snapshot.LastProgressChapter != playbackProgressEvent.Chapter)
+        var titleChanged = context.Snapshot.LastProgressTitle != playbackProgressEvent.Title;
+        var chapterChanged = context.Snapshot.LastProgressChapter != playbackProgressEvent.Chapter;
+
+        // Decide whether the new title/chapter invalidates the snapshot:
+        //  - movie: the progress bar spans the whole title (the player reports title time), so chapters
+        //    are just position markers within the same media – only a title change needs a rebuild.
+        //  - audio (non-movie): a chapter is a track, so any title or chapter change is a new track –
+        //    rebuild for fresh track metadata/cover.
+        var requiresRebuild = context.Snapshot.IsMovie ? titleChanged : titleChanged || chapterChanged;
+
+        if (requiresRebuild)
         {
             await RebuildSnapshotAndRefreshHdrTimestampAsync(context, cancellationToken);
             context.Snapshot.LastProgressTitle = playbackProgressEvent.Title;
@@ -808,7 +811,10 @@ public partial class OppoWebSocketHandler
             return MediaPlayerUpdateType.Full;
         }
 
-        // Same title/chapter – apply progress directly from event (no rebuild needed)
+        // No rebuild (movie with only a chapter change, or nothing changed). Keep the chapter tracked
+        // so the next change is detected, then apply progress directly from the event.
+        context.Snapshot.LastProgressChapter = playbackProgressEvent.Chapter;
+
         var elapsedChanged = UpdateProgress(context.Snapshot, playbackProgressEvent);
         return elapsedChanged ? MediaPlayerUpdateType.DeltaProgress : MediaPlayerUpdateType.Nothing;
     }

--- a/src/UnfoldedCircle.OppoBluRay/WebSocket/OppoWebSocketHandler.EntityEvent.cs
+++ b/src/UnfoldedCircle.OppoBluRay/WebSocket/OppoWebSocketHandler.EntityEvent.cs
@@ -815,6 +815,12 @@ public partial class OppoWebSocketHandler
         // so the next change is detected, then apply progress directly from the event.
         context.Snapshot.LastProgressChapter = playbackProgressEvent.Chapter;
 
+        // Movies report title-relative time; ignore any stray chapter-domain code so the position
+        // stays consistent with MediaDuration (full title) and does not reset at each chapter.
+        if (context.Snapshot.IsMovie
+            && playbackProgressEvent.TimeCodeType is OppoTimeCodeType.ChapterElapsed or OppoTimeCodeType.ChapterRemaining)
+            return MediaPlayerUpdateType.Nothing;
+
         var elapsedChanged = UpdateProgress(context.Snapshot, playbackProgressEvent);
         return elapsedChanged ? MediaPlayerUpdateType.DeltaProgress : MediaPlayerUpdateType.Nothing;
     }

--- a/src/UnfoldedCircle.OppoBluRay/WebSocket/OppoWebSocketHandler.Oppo.cs
+++ b/src/UnfoldedCircle.OppoBluRay/WebSocket/OppoWebSocketHandler.Oppo.cs
@@ -36,7 +36,7 @@ public partial class OppoWebSocketHandler
 
         if (entity is not null)
             return new OppoClientKey(entity.Host, entity.Model, entity.UseMediaEvents,
-                entity.UseStreamingEvents, entity.UseChapterLengthForMovies,
+                entity.UseStreamingEvents,
                 entity.EntityId, entity.DeviceId, entity.MacAddress);
 
         _logger.NoConfigurationFoundForIdentifier(wsId, localIdentifier ?? default, identifierType);
@@ -56,7 +56,7 @@ public partial class OppoWebSocketHandler
 
         return configuration.Entities
             .Select(static entity => new OppoClientKey(entity.Host, entity.Model, entity.UseMediaEvents,
-                entity.UseStreamingEvents, entity.UseChapterLengthForMovies,
+                entity.UseStreamingEvents,
                 entity.EntityId, entity.DeviceId, entity.MacAddress))
             .ToArray();
     }

--- a/src/UnfoldedCircle.OppoBluRay/WebSocket/OppoWebSocketHandler.cs
+++ b/src/UnfoldedCircle.OppoBluRay/WebSocket/OppoWebSocketHandler.cs
@@ -316,30 +316,6 @@ public partial class OppoWebSocketHandler(
                 },
                 new Setting
                 {
-                    Id = OppoConstants.ChapterOrMovieLengthKey,
-                    Field = new SettingTypeDropdown
-                    {
-                        Dropdown = new SettingTypeDropdownInner
-                        {
-                            Value = configurationItem?.UseChapterLengthForMovies == true ? OppoConstants.ChapterLengthValue : OppoConstants.MovieLengthValue,
-                            Items = [
-                                new SettingTypeDropdownItem
-                                {
-                                    Label = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["en"] = "Chapter Length" },
-                                    Value = OppoConstants.ChapterLengthValue
-                                },
-                                new SettingTypeDropdownItem
-                                {
-                                    Label = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["en"] = "Movie Length" },
-                                    Value = OppoConstants.MovieLengthValue
-                                }
-                            ]
-                        }
-                    },
-                    Label = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["en"] = "Use chapter or movie length for progress bar (only applicable if Media Events is enabled)? - Oppo Only" }
-                },
-                new Setting
-                {
                     Id = OppoConstants.MaxMessageHandlingWaitTimeInSecondsKey,
                     Field = new SettingTypeNumber
                     {
@@ -368,15 +344,11 @@ public partial class OppoWebSocketHandler(
         var useStreamingEvents = payload.MsgData.InputValues!.TryGetValue(OppoConstants.UseStreamingEventsKey, out var useStreamingEventsValue) &&
                                  useStreamingEventsValue.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
-        var useChapterLengthForMovies = payload.MsgData.InputValues!.TryGetValue(OppoConstants.ChapterOrMovieLengthKey, out var chapterOrMovieLengthValue) &&
-                                        chapterOrMovieLengthValue.Equals(OppoConstants.ChapterLengthValue, StringComparison.OrdinalIgnoreCase);
-
         var newConfigurationItem = configurationItem with
         {
             Model = oppoModel,
             UseMediaEvents = useMediaEvents,
-            UseStreamingEvents = useStreamingEvents,
-            UseChapterLengthForMovies = useChapterLengthForMovies
+            UseStreamingEvents = useStreamingEvents
         };
         var configuration = await _configurationService.GetConfigurationAsync(cancellationToken);
         configuration.Entities.Remove(configurationItem);
@@ -451,10 +423,6 @@ public partial class OppoWebSocketHandler(
             ? useStreamingEventsValue.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase)
             : null;
 
-        bool? useChapterLengthForMovies = payload.MsgData.InputValues!.TryGetValue(OppoConstants.ChapterOrMovieLengthKey, out var chapterOrMovieLengthValue)
-                                        ? chapterOrMovieLengthValue.Equals(OppoConstants.ChapterLengthValue, StringComparison.OrdinalIgnoreCase)
-                                        : null;
-
         var entity = configuration.Entities.FirstOrDefault(x => x.EntityId.Equals(host, StringComparison.OrdinalIgnoreCase));
         if (entity is null)
         {
@@ -468,7 +436,6 @@ public partial class OppoWebSocketHandler(
                 EntityId = host,
                 UseMediaEvents = useMediaEvents ?? false,
                 UseStreamingEvents = useStreamingEvents ?? false,
-                UseChapterLengthForMovies = useChapterLengthForMovies ?? false,
                 MacAddress = macAddress
             };
         }
@@ -479,7 +446,6 @@ public partial class OppoWebSocketHandler(
             entity = entity with
             {
                 Host = host,
-                UseChapterLengthForMovies = useChapterLengthForMovies ?? entity.UseChapterLengthForMovies,
                 UseMediaEvents = useMediaEvents ?? entity.UseMediaEvents,
                 EntityName = entityName,
                 Model = oppoModel


### PR DESCRIPTION
The chapter length report requires switching the reported time type on the receiver. Not worth the complexities involved in tracking what users have set.