### PR TITLE
Fix reconnect guard in SendCommandCore never firing

### DIFF
--- a/src/Oppo/OppoClient.cs
+++ b/src/Oppo/OppoClient.cs
@@ -1237,8 +1237,9 @@ public sealed class OppoClient(string hostName, in OppoModel model, ILogger<Oppo
             if (_logger.IsEnabled(LogLevel.Trace))
                 _logger.SendingCommand(Encoding.ASCII.GetString(command));
 
-            if (Interlocked.CompareExchange(ref _failedResponseCount, 0, 2) > 2)
+            if (Volatile.Read(ref _failedResponseCount) > 2)
             {
+                Interlocked.Exchange(ref _failedResponseCount, 0);
                 _logger.TooManyFailedResponses(caller);
 
                 _tcpClient.Close();


### PR DESCRIPTION
Fixes #379.

```diff
-            if (Interlocked.CompareExchange(ref _failedResponseCount, 0, 2) > 2)
+            if (Volatile.Read(ref _failedResponseCount) > 2)
             {
+                Interlocked.Exchange(ref _failedResponseCount, 0);
                 _logger.TooManyFailedResponses(caller);
```

I went with the second option from the issue (read, then reset inside the `if`) rather than a bare `Interlocked.Exchange` in the condition. A bare `Exchange` would clear the counter on *every* command, so a steady one-failure-per-command pattern would sit at 1 at each check and never reach the threshold — the same "never fires" outcome in a different disguise. Resetting only when the reconnect actually runs lets failures accumulate across commands and restarts the count after recovery.

Verified the semantics with a small standalone harness rather than by inspection.

Before:

```
--- 1 failed parse per command ---
  cmd 1: count before check=1, reconnect fired=False, count after=1
  cmd 2: count before check=2, reconnect fired=False, count after=0
  cmd 3: count before check=1, reconnect fired=False, count after=1
  cmd 4: count before check=2, reconnect fired=False, count after=0
--- 2 failed parses between checks ---
  cmd 1: count before check=2, reconnect fired=False, count after=0
  cmd 2: count before check=2, reconnect fired=False, count after=0
```

After:

```
--- 1 failed parse per command ---
  cmd 1: count=1, reconnect=False, after=1
  cmd 2: count=2, reconnect=False, after=2
  cmd 3: count=3, reconnect=True,  after=0
  cmd 4: count=1, reconnect=False, after=1
--- accumulated 4 failures, then healthy ---
  next cmd: reconnect=True,  after=0
  next cmd: reconnect=False, after=0
```

**Threshold left as-is, but worth a decision.** I kept the existing `> 2` comparison, so the reconnect now fires on the third accumulated failure. If the original intent was "reconnect after two failed responses" — which would line up with the `2` that was being used as the comparand, and with the two-failure case you described in #379 — then this should be `>= 2` instead. Happy to change it; I didn't want to alter the threshold silently while fixing the mechanism.

**Correction on my part:** you're right about the rate limiting, and my "dozen-plus reconnects per second" in the issue was wrong. `SendCommand` acquires the token-bucket lease before calling `SendCommandCore`, so the reconnect sits behind the limiter and ~10rps is the ceiling, not the 16/s I extrapolated from the 1s poll of the query set. The bug and the log spam are real, but I overstated the throughput — thanks for catching it.

**On whether this is the lockup:** your multiplexer observation looks decisive against it, and I'd rather say so than let the issue imply more than it shows. If a Rust proxy holds the single player-side connection and the lockup still happens, then client-side reconnect churn can't be the cause, since none of it reaches the player. That also matches what we saw testing directly against a UDP-203 (firmware `UDP20X-65-0131`) this evening with a raw socket script and no integration in the loop: ~1,900 consecutive `#QST` calls against a playing audio CD (`QPL` reporting `PLAY`, `QST` returning `ER INVALID` throughout), ~2,200 more at a UHD disc menu, pipelined floods, 85 no-response commands, and sequential and overlapping connect/query/close churn at 16/s — the player answered everything and never degraded. The one thing that did degrade it was four concurrent connections, which is the known single-client limitation rather than this.

So this PR is offered purely as a correctness fix for the guard, not as a lockup fix.
